### PR TITLE
Fix range split for rmd160-bsgs

### DIFF
--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -7146,9 +7146,14 @@ void *thread_process_rmd160_bsgs(void *vargp) {
                 remaining.Sub(&key);
                 remaining.AddOne();
 
-                uint64_t blk = remaining.GetInt64();
-                if(blk > RMD160_BSGS_TABLE_SIZE)
+                Int limit;
+                limit.SetInt64(RMD160_BSGS_TABLE_SIZE);
+                uint64_t blk;
+                if(remaining.IsGreater(&limit)){
                         blk = RMD160_BSGS_TABLE_SIZE;
+                }else{
+                        blk = remaining.GetInt64();
+                }
 
                 generate_block(&key,blk,table);
                 compare_block(table,blk);

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -2344,12 +2344,11 @@ int main(int argc, char **argv)	{
 			MPZAUX.Set(&seconds);
 			MPZAUX.Mod(&OUTPUTSECONDS);
 			if(MPZAUX.IsZero()) {
-				total.SetInt32(0);
-				for(j = 0; j < NTHREADS; j++) {
-					pretotal.Set(&debugcount_mpz);
-					pretotal.Mult(steps[j]);					
-					total.Add(&pretotal);
-				}
+                                total.SetInt32(0);
+                                for(j = 0; j < NTHREADS; j++) {
+                                        pretotal.SetInt64(steps[j]);
+                                        total.Add(&pretotal);
+                                }
 				
 				if(FLAGENDOMORPHISM)	{
 					if(FLAGMODE == MODE_XPOINT)	{
@@ -7142,10 +7141,23 @@ void *thread_process_rmd160_bsgs(void *vargp) {
         mlock(table, sizeof(struct rmd160_entry)*RMD160_BSGS_TABLE_SIZE);
 #endif
         while(key.IsLowerOrEqual(&thread_end)){
-                generate_block(&key,RMD160_BSGS_TABLE_SIZE,table);
-                compare_block(table,RMD160_BSGS_TABLE_SIZE);
+                Int remaining;
+                remaining.Set(&thread_end);
+                remaining.Sub(&key);
+                remaining.AddOne();
+
+                uint64_t blk = remaining.GetInt64();
+                if(blk > RMD160_BSGS_TABLE_SIZE)
+                        blk = RMD160_BSGS_TABLE_SIZE;
+
+                generate_block(&key,blk,table);
+                compare_block(table,blk);
+                steps[thread_number]+=blk;
+
+                if(blk < RMD160_BSGS_TABLE_SIZE)
+                        break;
+
                 key.Add(&inc);
-                steps[thread_number]+=RMD160_BSGS_TABLE_SIZE;
         }
 #if defined(_WIN64) && !defined(__CYGWIN__)
         VirtualUnlock(table, sizeof(struct rmd160_entry)*RMD160_BSGS_TABLE_SIZE);

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -7089,14 +7089,44 @@ void *thread_process_rmd160_bsgs(void *vargp) {
         free(tt);
         if(NTHREADS > 1)
                 omp_set_num_threads(1);
-        Int key,offset,inc;
-        offset.SetInt64(RMD160_BSGS_TABLE_SIZE);
-        offset.Mult((uint64_t)thread_number);
-        key.Set(&n_range_start);
-        key.Add(&offset);
+        Int key,inc,range_size,per_thread,remainder,thread_start,thread_end,tmp;
+
+        /* Calculate the range size and split it between the threads */
+        range_size.Set(&n_range_end);
+        range_size.Sub(&n_range_start);
+        range_size.AddOne();
+
+        tmp.SetInt32(NTHREADS);
+        per_thread.Set(&range_size);
+        per_thread.Div(&tmp,&remainder);
+
+        /* Compute the starting key for this thread */
+        thread_start.Set(&per_thread);
+        thread_start.Mult((uint64_t)thread_number);
+        thread_start.Add(&n_range_start);
+        uint64_t rem = remainder.GetInt64();
+        if((uint64_t)thread_number < rem){
+                Int extra; extra.SetInt64(thread_number);
+                thread_start.Add(&extra);
+        }else{
+                Int extra; extra.SetInt64(rem);
+                thread_start.Add(&extra);
+        }
+
+        /* Compute the ending key for this thread */
+        thread_end.Set(&per_thread);
+        if((uint64_t)thread_number < rem){
+                thread_end.AddOne();
+        }
+        thread_end.Add(&thread_start);
+        thread_end.SubOne();
+
+        /* Setup the increment between blocks */
         inc.SetInt64(RMD160_BSGS_TABLE_SIZE);
-        Int tmp; tmp.SetInt32(NTHREADS);
+        tmp.SetInt32(NTHREADS);
         inc.Mult(&tmp);
+
+        key.Set(&thread_start);
 #if defined(_WIN64) && !defined(__CYGWIN__)
         struct rmd160_entry *table = (struct rmd160_entry*)_aligned_malloc(sizeof(struct rmd160_entry)*RMD160_BSGS_TABLE_SIZE,64);
 #else
@@ -7111,7 +7141,7 @@ void *thread_process_rmd160_bsgs(void *vargp) {
 #else
         mlock(table, sizeof(struct rmd160_entry)*RMD160_BSGS_TABLE_SIZE);
 #endif
-        while(key.IsLowerOrEqual(&n_range_end)){
+        while(key.IsLowerOrEqual(&thread_end)){
                 generate_block(&key,RMD160_BSGS_TABLE_SIZE,table);
                 compare_block(table,RMD160_BSGS_TABLE_SIZE);
                 key.Add(&inc);


### PR DESCRIPTION
## Summary
- split the key range across all threads for rmd160-bsgs mode
- ensure each thread stops at its assigned range

## Testing
- `make -j4`
- `./keyhunt -m rmd160-bsgs -f tests/64.rmd -r 1:1000 -t 2 -q | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6856eeb49b788322ac9cb7eafa286b74